### PR TITLE
Fix module inclusion and XPath lookup

### DIFF
--- a/lib/capybara/angular/material.rb
+++ b/lib/capybara/angular/material.rb
@@ -4,7 +4,6 @@ require 'capybara/angular/material/node/actions'
 module Capybara
   module Angular
     module Material
-      include Capybara::RSpecMatchers
       include Capybara::Angular::Material::RSpecMatchers
       include Capybara::Angular::Material::Node::Actions
     end

--- a/lib/capybara/angular/material/node/actions.rb
+++ b/lib/capybara/angular/material/node/actions.rb
@@ -4,16 +4,16 @@ module Capybara
       module Node
         module Actions
           def md_check(locator)
-            find(:xpath, "//md-checkbox/*/span[normalize-space(text())='#{locator}']").click
+            find(:xpath, "//md-checkbox/*/*[normalize-space(text())='#{locator}']").click
           end
 
           def md_uncheck(locator)
-            find(:xpath, "//md-checkbox/*/span[normalize-space(text())='#{locator}']").click
+            find(:xpath, "//md-checkbox/*/*[normalize-space(text())='#{locator}']").click
           end
 
           def md_select(value, options={})
             # trigger('click') prevents an overlapping element error.
-            find(:xpath, "//md-select/md-select-value/span[not(@class)][text()='#{options[:from]}']").trigger('click')
+            find(:xpath, "//md-select/md-select-value/*[not(@class)][text()='#{options[:from]}']").trigger('click')
             find(
               :xpath,
               %{
@@ -27,7 +27,7 @@ module Capybara
           private
 
           def select_md_text_xpath
-            "//md-select-value/span/*[contains(@class, 'md-text')]"
+            "//md-select-value/*/*[contains(@class, 'md-text')]"
           end
         end
       end

--- a/lib/capybara/angular/material/rspec.rb
+++ b/lib/capybara/angular/material/rspec.rb
@@ -2,6 +2,8 @@ module Capybara
   module Angular
     module Material
       module RSpecMatchers
+        include ::Capybara::RSpecMatchers
+
         def have_md_button(locator)
           HaveSelector.new(:xpath, "//button[contains(@class, 'md-button')]/span[normalize-space(text())='#{locator}']")
         end

--- a/lib/capybara/angular/material/rspec.rb
+++ b/lib/capybara/angular/material/rspec.rb
@@ -5,11 +5,11 @@ module Capybara
         include ::Capybara::RSpecMatchers
 
         def have_md_button(locator)
-          HaveSelector.new(:xpath, "//button[contains(@class, 'md-button')]/span[normalize-space(text())='#{locator}']")
+          HaveSelector.new(:xpath, "//button[contains(@class, 'md-button')]/*[normalize-space(text())='#{locator}']")
         end
 
         def have_md_checkbox(locator, options={})
-          HaveSelector.new(:xpath, "//md-checkbox#{aria_checked(options)}#{ng_disabled(options)}/*/span[normalize-space(text())='#{locator}']")
+          HaveSelector.new(:xpath, "//md-checkbox#{aria_checked(options)}#{ng_disabled(options)}/*/*[normalize-space(text())='#{locator}']")
         end
 
         def have_md_list
@@ -21,11 +21,11 @@ module Capybara
         end
 
         def have_md_radio_button(locator, options={})
-          HaveSelector.new(:xpath, "//md-radio-button#{aria_checked(options)}/*/span[normalize-space(text())='#{locator}']")
+          HaveSelector.new(:xpath, "//md-radio-button#{aria_checked(options)}/*/*[normalize-space(text())='#{locator}']")
         end
 
         def have_md_select(locator, options={})
-          HaveSelector.new(:xpath, "//md-select/md-select-value/span[not(@class)][text()='#{locator}']")
+          HaveSelector.new(:xpath, "//md-select/md-select-value/*[not(@class)][text()='#{locator}']")
         end
 
         private


### PR DESCRIPTION
+ Module inclusion: My test doesn't work because of `HaveSelector` not found. Simply move `include Capybara::RSpecMatchers` into `Capybara::Angular::Material::RSpecMatchers` make it work.
+ XPath lookup: text is not always inside `span` element so I have to modify XPath a bit.